### PR TITLE
check new caddy release seprate from main build file

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -3,8 +3,6 @@ name: Build and Push CS-Caddy to GHCR and Docker Hub
 on:
   repository_dispatch:
     types: [caddy-release, bouncer-release]
-  schedule:
-    - cron: '0 3 * * *'
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/check-caddy-release.yml
+++ b/.github/workflows/check-caddy-release.yml
@@ -1,0 +1,31 @@
+name: Check for New Caddy Release
+
+on:
+  schedule:
+    - cron: '5 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Get latest Caddy release tag
+        id: get_tag
+        run: |
+          LATEST_TAG=$(curl -s "https://api.github.com/repos/caddyserver/caddy/releases/latest" | jq -r .tag_name)
+          echo "LATEST_TAG=${LATEST_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Check if release tag is new by using it as a cache key
+        id: check
+        uses: actions/cache@v4
+        with:
+          path: .cache/caddy-tag
+          key: caddy-release-${{ steps.get_tag.outputs.LATEST_TAG }}
+
+      - name: Trigger build workflow if new release found
+        if: steps.check.outputs.cache-hit != 'true'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: caddy-release


### PR DESCRIPTION
Removed cron from main build and push file and added separate caddy release check, this will eliminate the need for a new build every day. 